### PR TITLE
Make optional loading of decorators

### DIFF
--- a/lib/spina.rb
+++ b/lib/spina.rb
@@ -12,11 +12,12 @@ module Spina
   PLUGINS = []
   THEMES = []
 
-  config_accessor :backend_path, :disable_frontend_routes, :storage, :max_page_depth, :locales, :embedded_image_size
+  config_accessor :backend_path, :disable_frontend_routes, :storage, :max_page_depth, :locales, :embedded_image_size, :disable_decorator_load
 
   self.backend_path = 'admin'
 
   self.disable_frontend_routes = false
+  self.disable_decorator_load = false
 
   self.storage = :file
 

--- a/lib/spina/engine.rb
+++ b/lib/spina/engine.rb
@@ -23,9 +23,11 @@ module Spina
       # Load helpers from main application
       Spina::ApplicationController.helper Rails.application.helpers
 
-      # Require decorators from main application
-      [Rails.root].flatten.map { |p| Dir[p.join('app', 'decorators', '**', '*_decorator.rb')]}.flatten.uniq.each do |decorator|
-        Rails.configuration.cache_classes ? require(decorator) : load(decorator)
+      unless Spina.config.disable_decorator_load
+        # Require decorators from main application
+        Dir[Rails.root.join('app', 'decorators', '**', '*_decorator.rb')].flatten.uniq.each do |decorator|
+          require_dependency(decorator)
+        end
       end
 
       # Register JSON part types for editing content


### PR DESCRIPTION
This change will fix issue with our decorators loading. at the moment - I've just mocked Spina::Engine:: Dir to return empty array and don't load decorators as our apps do that