### PR TITLE
Optional view template

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spina (2.0.0.paragon4)
+    spina (2.0.0.paragon5)
       ancestry
       attr_json
       bcrypt
@@ -112,7 +112,7 @@ GEM
       railties (>= 3.2, < 6.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    haml (5.2.0)
+    haml (5.2.1)
       temple (>= 0.8.0)
       tilt
     haml-rails (2.0.1)

--- a/app/helpers/spina/admin/pages_helper.rb
+++ b/app/helpers/spina/admin/pages_helper.rb
@@ -32,9 +32,13 @@ module Spina
       end
 
       def build_page_parts(page)
-        template_name = page.view_template.to_s
-        view_template = current_theme.view_templates.find{ |v| v[:name].to_s == template_name }
-        parts = view_template&.dig(:parts) || []
+        if page.view_template.present?
+          template_name = page.view_template.to_s
+          view_template = current_theme.view_templates.find{ |v| v[:name].to_s == template_name }
+          parts = view_template&.dig(:parts) || []
+        else
+          parts = page.parts
+        end
         build_parts(page, parts)
       end
 

--- a/app/models/concerns/spina/partable.rb
+++ b/app/models/concerns/spina/partable.rb
@@ -5,7 +5,6 @@ module Spina
     attr_accessor :view_context
 
     included do
-
       def part(attributes)
         part = find_part(attributes[:name]) || attributes[:part_type].constantize.new
 
@@ -27,10 +26,9 @@ module Spina
 
       private
 
-        def content_presenter
-          @content_presenter ||= ContentPresenter.new(view_context, self)
-        end
-
+      def content_presenter
+        @content_presenter ||= ContentPresenter.new(view_context, self)
+      end
     end
   end
 end

--- a/app/models/concerns/spina/translated_content.rb
+++ b/app/models/concerns/spina/translated_content.rb
@@ -3,7 +3,6 @@ module Spina
     extend ActiveSupport::Concern
 
     included do
-      
       # Store each locale's content in [locale]_content as an array of parts
       Spina.config.locales.each do |locale|
         attr_json "#{locale}_content".to_sym, AttrJson::Type::SpinaPartsModel.new, array: true, default: -> { [] }
@@ -11,9 +10,12 @@ module Spina
       end
 
       def find_part(name)
-        send("#{I18n.locale}_content").find{|part| part.name.to_s == name.to_s}
+        parts.find{|part| part.name.to_s == name.to_s}
       end
 
+      def parts
+        send("#{I18n.locale}_content")
+      end
     end
   end
 end

--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -22,7 +22,7 @@ module Spina
     scope :regular_pages, ->  { where(resource: nil) }
     scope :resource_pages, -> { where.not(resource: nil) }
     scope :active, -> { where(active: true) }
-    scope :sorted, -> { order(:position) }
+    scope :sorted, -> { i18n.order(:title) }
     scope :live, -> { active.where(draft: false) }
     scope :in_menu, -> { where(show_in_menu: true) }
 
@@ -94,7 +94,7 @@ module Spina
     private
 
       def set_resource_from_parent
-        self.resource_id = parent.resource_id 
+        self.resource_id = parent.resource_id
       end
 
       def touch_navigations

--- a/lib/spina/version.rb
+++ b/lib/spina/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Spina
-  VERSION = '2.0.0.paragon4'
+  VERSION = '2.0.0.paragon5'
 end


### PR DESCRIPTION
As a lot pages have different structure we end up defining a view template per page - so I propose to make "view template" optional and if it is not set - reflect it's content. it will introduce difficulties when a page structure should be changed but we maintain these changes anyway 