### PR TITLE
Enable position sort and make features configurable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    spina (2.0.0.paragon7)
+    spina (2.0.0.paragon8)
       ancestry
       attr_json
       bcrypt
@@ -13,7 +13,7 @@ PATH
       jsonb_accessor (>= 1.0.0)
       kaminari
       mini_magick
-      mobility (>= 0.8.9)
+      mobility (~> 0.8)
       pg
       rack-rewrite (>= 1.5.0)
       rails (>= 5.2)
@@ -83,8 +83,8 @@ GEM
     ancestry (3.2.1)
       activerecord (>= 4.2.0)
     ansi (1.5.0)
-    attr_json (1.2.0)
-      activerecord (>= 5.0.0, < 6.1)
+    attr_json (1.3.0)
+      activerecord (>= 5.0.0, < 6.2)
     bcrypt (3.1.16)
     breadcrumbs_on_rails (4.0.0)
       rails (>= 5.0)
@@ -107,7 +107,7 @@ GEM
     execjs (2.7.0)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
-    ffi (1.13.1)
+    ffi (1.14.2)
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
     globalid (0.4.2)

--- a/app/controllers/spina/admin/pages_controller.rb
+++ b/app/controllers/spina/admin/pages_controller.rb
@@ -88,7 +88,9 @@ module Spina
       end
 
       def set_tabs
-        @tabs = %w{page_content advanced}
+        @tabs = ['page_content']
+        @tabs << 'page_seo' if Spina.config.page_seo
+        @tabs << 'advanced' if Spina.config.advanced
       end
 
       def update_page_position(page, position, parent_id = nil)

--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -22,7 +22,7 @@ module Spina
     scope :regular_pages, ->  { where(resource: nil) }
     scope :resource_pages, -> { where.not(resource: nil) }
     scope :active, -> { where(active: true) }
-    scope :sorted, -> { i18n.order(:title) }
+    scope :sorted, -> { Spina.config.position_sort ? order(:position) : i18n.order(:title) }
     scope :live, -> { active.where(draft: false) }
     scope :in_menu, -> { where(show_in_menu: true) }
 

--- a/app/views/layouts/spina/admin/pages.html.haml
+++ b/app/views/layouts/spina/admin/pages.html.haml
@@ -1,17 +1,21 @@
 - content_for :application do
   %header#header
     #header_actions
-      = link_to '#pages_list', class: 'button button-default sort-switch', data: {change_order: t('spina.pages.change_order'), done_changing_order: t('spina.pages.done_changing_order')} do
-        .button-content
-          = icon_spina('random')
-          = t('spina.pages.change_order')
+      - if Spina.config.change_order
+        = link_to '#pages_list', class: 'button button-default sort-switch',
+            data: {change_order: t('spina.pages.change_order'),
+                   done_changing_order: t('spina.pages.done_changing_order')} do
+          .button-content
+            = icon_spina('random')
+            = t('spina.pages.change_order')
 
       = yield(:header_actions) if content_for?(:header_actions)
 
-    .breadcrumbs
-      = render_breadcrumbs separator: '<div class="divider"></div>'
-      = link_to '/', class: 'button button-small button-default', target: :blank do
-        %i.fa.fa-external-link{style: "margin: 0"}
+    - unless Spina.config.disable_frontend_routes
+      .breadcrumbs
+        = render_breadcrumbs separator: '<div class="divider"></div>'
+        = link_to '/', class: 'button button-small button-default', target: :blank do
+          %i.fa.fa-external-link{style: "margin: 0"}
 
     %nav#secondary.tabs
       %ul

--- a/app/views/spina/admin/pages/_form.html.haml
+++ b/app/views/spina/admin/pages/_form.html.haml
@@ -27,8 +27,10 @@
                   %li
                     = link_to t("spina.languages.#{locale}"), "?locale=#{locale}", style: ('font-weight: 600' if @locale.to_s == locale.to_s).to_s
 
-        = link_to @page.materialized_path, target: :blank, class: 'button button-default button-small', style: 'margin-left: 0' do
-          %i.fa.fa-external-link{style: 'margin: 0'}
+        - unless Spina.config.disable_frontend_routes
+          = link_to @page.materialized_path, target: :blank,
+              class: 'button button-default button-small', style: 'margin-left: 0' do
+            %i.fa.fa-external-link{style: 'margin: 0'}
 
     #header_actions
       %button.button.button-primary{type: 'submit', style: 'margin-right: 0', data: {disable_with: t('spina.pages.saving')}}

--- a/app/views/spina/admin/pages/_form_page_content.html.haml
+++ b/app/views/spina/admin/pages/_form_page_content.html.haml
@@ -1,10 +1,11 @@
 #page_content.tab-content.active
 
   .page-form
-    .page-form-group
-      .page-form-label= Spina::Page.human_attribute_name :title
-      .page-form-control
-        = f.text_field :title, placeholder: Spina::Page.human_attribute_name(:title_placeholder), class: 'input-large'
+    - if Spina.config.edit_title
+      .page-form-group
+        .page-form-label= Spina::Page.human_attribute_name :title
+        .page-form-control
+          = f.text_field :title, placeholder: Spina::Page.human_attribute_name(:title_placeholder), class: 'input-large'
 
     = f.fields_for "#{@locale}_content".to_sym, build_page_parts(f.object) do |ff|
       = ff.hidden_field :type, value: ff.object.class

--- a/app/views/spina/admin/pages/index.html.haml
+++ b/app/views/spina/admin/pages/index.html.haml
@@ -1,9 +1,13 @@
 - content_for(:header_actions) do
   %span{data: {dropdown: true}}
-    = link_to spina.new_admin_page_path(params: {view_template: 'show'}), class: 'button button-primary', style: 'margin-right: 0', data: {trigger: ('dropdown' if current_theme.new_page_templates.size > 1), target: '#create_page_dropdown'} do
-      .button-content
-        = icon_spina('plus')
-        = t('spina.pages.new')
+    - if Spina.config.new_page
+      = link_to spina.new_admin_page_path(params: {view_template: 'show'}),
+          class: 'button button-primary', style: 'margin-right: 0',
+          data: {trigger: ('dropdown' if current_theme.new_page_templates.size > 1),
+                 target: '#create_page_dropdown'} do
+        .button-content
+          = icon_spina('plus')
+          = t('spina.pages.new')
 
     .sliding-dropdown#create_page_dropdown.align-right
       .slide-controls

--- a/lib/spina.rb
+++ b/lib/spina.rb
@@ -14,8 +14,9 @@ module Spina
   THEMES = []
 
   config_accessor :backend_path, :disable_frontend_routes, :storage,
-    :max_page_depth, :locales, :embedded_image_size, :disable_decorator_load,
-    :social_links
+                  :max_page_depth, :locales, :embedded_image_size, :disable_decorator_load,
+                  :social_links, :position_sort, :change_order, :new_page, :edit_title,
+                  :page_seo, :advanced
 
   self.backend_path = 'admin'
 
@@ -35,4 +36,15 @@ module Spina
   # Default: 2000x2000px
   self.embedded_image_size = "2000x2000>"
 
+  self.position_sort = false
+
+  self.change_order = true
+
+  self.new_page = true
+
+  self.edit_title = true
+
+  self.page_seo = true
+
+  self.advanced = true
 end

--- a/lib/spina/version.rb
+++ b/lib/spina/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Spina
-  VERSION = '2.0.0.paragon7'
+  VERSION = '2.0.0.paragon8'
 end

--- a/spina.gemspec
+++ b/spina.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'breadcrumbs_on_rails'
   s.add_dependency 'turbolinks', '~> 5'
   s.add_dependency 'kaminari'
-  s.add_dependency 'mobility', '>= 0.8.9'
+  s.add_dependency 'mobility', '~> 0.8'
   s.add_dependency 'rack-rewrite', '>= 1.5.0'
   s.add_dependency 'jsonb_accessor', '>= 1.0.0'
   s.add_dependency 'attr_json'


### PR DESCRIPTION
Apparently, the sorting should already have been by position, e.g. in
order to show the effects of changing the order.

Some features are not accessible by end-users, and some are unused
depending on the integration. They are now configurable per application.