### PR TITLE
Add updated_at to spina page and navigation cache key

### DIFF
--- a/app/models/spina/navigation.rb
+++ b/app/models/spina/navigation.rb
@@ -9,7 +9,7 @@ module Spina
     validates :name, uniqueness: true
 
     def cache_key
-      super + "_" + Mobility.locale.to_s
+      super + "_" + Mobility.locale.to_s + "_" + updated_at.to_s
     end
   end
 end

--- a/app/models/spina/page.rb
+++ b/app/models/spina/page.rb
@@ -83,7 +83,7 @@ module Spina
     end
 
     def cache_key
-      super + "_" + Mobility.locale.to_s
+      super + "_" + Mobility.locale.to_s + "_" + updated_at.to_s
     end
 
     def view_template_config(theme)

--- a/lib/spina/version.rb
+++ b/lib/spina/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Spina
-  VERSION = '2.0.0.ws5'
+  VERSION = '2.0.0.ws6'
 end


### PR DESCRIPTION
### Context

Spina::Page cache_key doesn't has timestamp column in it, as a result we can't use page in a cache key:

2.6.6 (main):0 > Spina::Page.last.cache_key
  Spina::Page Load (0.3ms)  SELECT "spina_pages".* FROM "spina_pages" ORDER BY "spina_pages"."id" DESC LIMIT $1  [["LIMIT", 1]]
=> "spina/pages/26_en"

### Changes proposed in this pull request

Added timestamp updated_at column to the cache_key for page and navigation

### Guidance to review

Run Spina::Page.last.cache_key
